### PR TITLE
Add terms and conditions quiz question

### DIFF
--- a/src/components/onboarding_quiz/OnboardingQuiz.js
+++ b/src/components/onboarding_quiz/OnboardingQuiz.js
@@ -28,6 +28,11 @@ function OnboardingQuiz(props) {
         "10 or more years ago", // Advanced
       ],
     },
+    {
+      question:
+        "Do you agree to be excellent towards yourself and other members of the Code and Coffee Philly group?",
+      choices: ["Yes", "No"],
+    },
   ]);
   const [answers, setAnswers] = React.useState([]);
 


### PR DESCRIPTION
I added a the following question to the onboarding quiz:

"Do you agree to be excellent towards yourself and the other members of the Coffee and Code Philly group?"

Currently, no validation is performed on any of the quiz questions. Ideally, in a future PR, it would be nice to confirm whether the correct answer of "yes" was selected before displaying the meetup/discord links (which are not currently rendered upon completion either).